### PR TITLE
Multiple config files

### DIFF
--- a/lib/dry/component/config.rb
+++ b/lib/dry/component/config.rb
@@ -3,8 +3,6 @@ require 'yaml'
 module Dry
   module Component
     class Config
-      extend Dry::Configurable
-
       def self.load(root, name, env)
         path = root.join('config').join("#{name}.yml")
 
@@ -12,11 +10,13 @@ module Dry
 
         yaml = YAML.load_file(path)
 
-        yaml.fetch(env.to_s).each do |key, value|
-          setting key.downcase.to_sym, ENV.fetch(key, value)
-        end
+        Class.new do
+          extend Dry::Configurable
 
-        config
+          yaml.fetch(env.to_s).each do |key, value|
+            setting key.downcase.to_sym, ENV.fetch(key, value)
+          end
+        end.config
       end
     end
   end

--- a/spec/fixtures/test/config/subapp.yml
+++ b/spec/fixtures/test/config/subapp.yml
@@ -1,0 +1,2 @@
+test:
+  bar: 'baz'

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -8,9 +8,20 @@ RSpec.describe Dry::Component::Config do
         config.root = SPEC_ROOT.join('fixtures/test').realpath
       end
     end
+
+    class Test::SubApp < Dry::Component::Container
+      configure do |config|
+        config.name = :subapp
+        config.root = SPEC_ROOT.join('fixtures/test').realpath
+      end
+    end
   end
 
   it 'loads config under component name' do
     expect(Test::App.options.foo).to eql('bar')
+  end
+
+  it 'allows different components to have different configurations' do
+    expect(Test::SubApp.options.bar).to eql('baz')
   end
 end


### PR DESCRIPTION
There's currently an error where you can't have multiple `yml` config files for different components.
Because `Dry::Component::Config` would get "locked" with the first loaded file's keys.